### PR TITLE
updated postcss with commonJS export syntax

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
the postcss.config.js was using the new ES6 export style, so updated it with older commonJS export style